### PR TITLE
feat: responsive menu

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -522,4 +522,19 @@
     .footer {
         width: 310px;
     }
+
+    /* responsive menu */
+
+    .nav__menu {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .nav__menu .nav__text {
+        margin: 10px;
+    }
+
+    .nav {
+        flex-direction: column;
+    }
 }


### PR DESCRIPTION
Simple responsive menu without burger implementation.

```javascript
/* responsive menu */
@media screen and (max-width: 760px) {
    .nav__menu {
        display: flex;
        flex-direction: column;
    }

    .nav__menu .nav__text {
        margin: 10px;
    }

    .nav {
        flex-direction: column;
    }
}
```

## Mobile 
 <img src="https://i.imgur.com/Z1aVmrQ.png" width="350">

## Desktop
 <img src="https://i.imgur.com/zJbeLe8.png" width="350">
